### PR TITLE
Fix diagram code concatenation logic

### DIFF
--- a/src/markdown_mermaid_cli/extension.py
+++ b/src/markdown_mermaid_cli/extension.py
@@ -117,7 +117,10 @@ class MermaidProcessor(Preprocessor):
                 break
 
             else:
-                diagram_code = diagram_code + '\n' + line
+                if diagram_code:
+                    diagram_code = diagram_code + '\n' + line
+                else:
+                    diagram_code = line
 
         return html_string
 


### PR DESCRIPTION
In the current code, a newline was prepended to every diagram. This broke front matter parsing. With this change, front matter (options enclosed in `--- ... ---` before the diagram) work again.