### PR TITLE
Only on PDF

### DIFF
--- a/src/markdown_mermaid_cli/extension.py
+++ b/src/markdown_mermaid_cli/extension.py
@@ -44,8 +44,9 @@ class MermaidProcessor(Preprocessor):
     ]
 
     def __init__(self, md, config):
-        format = config['default_format']
+        format = config.get('default_format', 'svg')
         self.format = format if format in VALID_FORMAT else 'svg'
+        self.scale = config.get('scale', '1')
         super().__init__(md)
 
     def run(self, lines: List[str]) -> List[str]:
@@ -106,14 +107,23 @@ class MermaidProcessor(Preprocessor):
                     if option in self.MERMAID_OPTIONS:
                         mermaid_options[option] = code_block_options[option].strip('"')
 
+                # Inject global scale if not overridden in code block
+                if 'scale' not in mermaid_options:
+                    mermaid_options['scale'] = self.scale
+
                 img_src = self._get_img_src(diagram_code, format, mermaid_options)
                 if img_src:
                     # Build the <img> tag with extracted options
-                    img_tag = f'<img src="{img_src}"'
+                    img_tag = f'<img class="mermaid-pdf-only" src="{img_src}"'
                     for key, value in img_tag_attributes.items():
                         img_tag += f' {key}={value}'
                     img_tag += ' />'
-                    html_string = img_tag
+                    
+                    # Also include the original code block for the web version
+                    # We wrap it so we can hide it in print
+                    # We use markdown="1" to ensure md_in_html processes the block inside
+                    web_code = "\n".join(lines)
+                    html_string = f'<div class="mermaid-wrapper"><div class="mermaid-web-only" markdown="1">\n\n{web_code}\n\n</div>{img_tag}</div>'
                 break
 
             else:
@@ -195,6 +205,10 @@ class MermaidExtension(Extension):
             'default_format': [
                 'svg',
                 'Set the default format to render the diagrams. - Default: svg',
+            ],
+            'scale': [
+                '1',
+                'Set the default scale factor for PNG output. - Default: 1',
             ]
         }
         super().__init__(**kwargs)


### PR DESCRIPTION
### !!! This requires changes before merging !!!

Hi there, 

We had two issues with our pipeline using this tool. 1. The SVG version for some reason didn't render fonts anymore and 2. The image in the HTML version was ugly (especially in darkmode). So I made these change in my fork.

This changes two things

1. It makes the scale parameter option accessible for the user (So that we can use high-res PNGs (they have no issues with fonts))
2. It practically "separates" the two pipelines, s.t. the HTML version still is rendered by the normal JS logic (giving nice theming and searchable text) and the PDF has the images. For this to work I added some lines to our extra.css:

```css
/* Mermaid Dual Rendering Support */
.mermaid-pdf-only {
  display: none;
}
@media print {
  .mermaid-pdf-only {
    display: block !important;
    max-width: 100%;
    height: auto;
    margin: 1em auto;
  }
  .mermaid-web-only, .mermaid {
    display: none !important;
  }
}
```

Technically this just includes both and hides the irrelevant one.

This works for us and we do not need action from your side. 

If you want to implement something like this the CSS would need to be in the HTML as well somehow. I guess just adding it as inline `<style>` block would work, but maybe you can think of a more elegant solution.

Thanks for your work!